### PR TITLE
Total rewrite of horizon-sync

### DIFF
--- a/ckx/package.json
+++ b/ckx/package.json
@@ -9,6 +9,7 @@
     "build": "./node_modules/.bin/webpack --config webpack.config.production.js && cp index.html dist",
     "lint": "./node_modules/.bin/eslint .",
     "hz": "./node_modules/.bin/hz serve",
+    "admin": "open http://localhost:8080",
     "deploy": "npm run build && docker build -t houshuang/rethink . && docker push houshuang/rethink && docker $(docker-machine config prod) pull houshuang/rethink && docker $(docker-machine config prod) stop $(docker $(docker-machine config prod) ps -a -q) && docker $(docker-machine config prod) run -d -p 80:8181 houshuang/rethink"
   },
   "repository": {

--- a/horizon-redux-sync/package.json
+++ b/horizon-redux-sync/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel src --presets babel-preset-es2015 --out-dir dist",
+    "build": "babel src --presets babel-preset-es2015,babel-preset-stage-0 --out-dir dist",
+    "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
   "keywords": [
@@ -21,7 +22,10 @@
     "babel-preset-es2015": "^6.6.0"
   },
   "dependencies": {
+    "babel-preset-stage-0": "^6.5.0",
     "deep-equal": "^1.0.1",
-    "json-path": "^0.1.3"
+    "json-path": "^0.1.3",
+    "lodash": "^4.12.0",
+    "watch": "^0.18.0"
   }
 }


### PR DESCRIPTION
This is quite a large rewrite of horizon-sync, which should address most of our issues. I switched from using the raw changefeed, to letting horizon maintain state, and syncing against its tree. This means that I diff both the Horizon state, and the Redux state. I also rewrote the diff algorithm to be simpler and more robust.
