### PR TITLE
Adding NPM script runall

### DIFF
--- a/ckx/package.json
+++ b/ckx/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js & npm run hz",
+    "startall": "npm run watch_encore & npm run watch_hz & node server.js & npm run hz",
+    "watch_encore": "cd ../encore_login && npm run watch &",
+    "watch_hz": "cd ../horizon-redux-sync && npm run watch &",
     "web": "node server.js",
     "build": "./node_modules/.bin/webpack --config webpack.config.production.js && cp index.html dist",
     "lint": "./node_modules/.bin/eslint .",

--- a/encore_login/package.json
+++ b/encore_login/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "babel src --presets babel-preset-react,babel-preset-es2015 --out-dir dist",
+    "watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build"
   },
   "repository": {
@@ -23,7 +24,8 @@
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0"
+    "babel-preset-react": "^6.5.0",
+    "watch": "^0.18.0"
   },
   "author": "Stian Håklev (shaklev@gmail.com)",
   "license": "MIT",


### PR DESCRIPTION
This script also watches encore_login and horizon-redux-sync and automatically compiles ES5 whenever a change occurs.
