### PR TITLE
Adding class_state syncing and cleaning up encore_login callback format

### DIFF
--- a/ckx/app/components/Student/StudentView.jsx
+++ b/ckx/app/components/Student/StudentView.jsx
@@ -3,10 +3,9 @@ import { connect } from 'react-redux';
 import StudentReadView from './StudentReadView'
 import StudentWriteView from './StudentWriteView'
 import LockedView from './LockedView'
-import { currentDate } from '../../lib/utils'
+import { currentDate, getKey } from '../../lib/utils'
 
-
-const StudentViewEl = ({ ui, observations, studentState, dispatch }) => {
+const StudentViewEl = ({ ui, classState, observations, studentState, dispatch }) => {
   // need to standardize where the functionality resides (eg submit cancel is here, but 'add obs' is one down)
   const cancelNewObservation = () => {
     dispatch({type: 'UNSETEDIT_UI'});
@@ -25,7 +24,7 @@ const StudentViewEl = ({ ui, observations, studentState, dispatch }) => {
   };
 
   let boardEl;
-  if (ui.tabletsLocked) {
+  if (getKey('tablets_locked', classState)) {
     boardEl = <LockedView />
   } else {
     if (ui.activeView === 'write') {
@@ -55,6 +54,6 @@ const StudentViewEl = ({ ui, observations, studentState, dispatch }) => {
 
 
 // connect is a curried component that maps the state from redux (first call) to a presentational component (second call, in this case List)
-const StudentView = connect(e => ({ui: e.ui, observations: e.observations, studentState: e.studentState}))(StudentViewEl)
+const StudentView = connect(e => ({ui: e.ui, classState: e.classState, observations: e.observations, studentState: e.studentState}))(StudentViewEl)
 // thinking about moving the orderBy to here? Need to understand/unpack this connect thing more...
 export default StudentView

--- a/ckx/app/lib/utils.js
+++ b/ckx/app/lib/utils.js
@@ -14,3 +14,15 @@ export const shorten = (text, length) => {
     return t.slice(0, length-3)+'...'
   }
 }
+
+export const identity = (e) => e
+
+// for classState and studentState, we are getting an array from Horizon, but
+// we will only have one element of each type with a given class/student ID
+// this let's us easily pick that element out and switch on it
+// for example getKey('tablet_locked', classState) will return the value if
+// the element exists, and undefined if it does not
+export const getKey = (key, array) => {
+  const elem = array.filter(e => e.type == key)[0]
+  return elem ? elem.value : undefined
+}

--- a/ckx/app/reducers.js
+++ b/ckx/app/reducers.js
@@ -4,9 +4,11 @@ import observations from './reducers/observations'
 import ui from './reducers/ui'
 import studentState from './reducers/studentState'
 import factory from './reducers/factory'
+import { identity } from './lib/utils'
 
 export default combineReducers({
   observations: crud('OBSERVATION', observations, [], {x: 0, y: 0}),
   ui: factory('UI', {infoOpen: false, addOpen: false, loggedIn: false, tabletsLocked: false}, ui),
   studentState: factory('studentState', studentState),
+  classState: crud('CLASS_STATE', identity, [])
 })

--- a/ckx/app/reducers/ui.js
+++ b/ckx/app/reducers/ui.js
@@ -10,17 +10,12 @@ export default (state, action) => {
       return {...state, fields: action.fields}
     case 'SETNAME':
       return {...state, user: action.name}
+    case 'SETCLASS':
+      return {...state, class: action.class}
     case 'SETROLE':
       return {...state, role: action.role}
     case 'LOGGEDIN':
       return {...state, loggedIn: true}
-
-    /***** BOARDS *****/
-
-    case 'LOCKTABLETS':
-      return {...state, tabletsLocked: true}
-    case 'UNLOCKTABLETS':
-      return {...state, tabletsLocked: false}
 
     /***** TABLETS *****/
 

--- a/ckx/app/router.jsx
+++ b/ckx/app/router.jsx
@@ -32,20 +32,24 @@ export const changeRoute = (route) => {
 }
 
 const selectFn = (callback) => {
-  console.log("User selected, info passed from callback function: ", callback)
   window.store.dispatch({
     type: 'SETNAME_UI',
-    name: callback.name
+    name: callback.student.name
+  });
+  window.store.dispatch({
+    type: 'SETCLASS_UI',
+    class: callback.student.class
   });
   window.store.dispatch({
     type: 'SETROLE_UI',
-    role: callback.role
+    role: callback.student.role
   });
   window.store.dispatch({
     type: 'LOGGEDIN_UI'
   });
 
   horizonSync(horizon, store, '/observations', callback.CO.collection, 'OBSERVATIONS')
+  horizonSync(horizon, store, '/class_state', 'class_state', 'CLASS_STATE', {class: callback.student.class}, {readOnly: true})
 
   store.dispatch({
     type: 'SETBOARD_UI',
@@ -56,7 +60,7 @@ const selectFn = (callback) => {
     fields: JSON.parse(callback.CO.prompt).prompt
   });
 
-  if (window.store.getState().ui.role === "board") {
+  if (callback.student.role === "board") {
     changeRoute('board');
   } else {
     changeRoute('student');

--- a/encore_login/src/hardcoded.js
+++ b/encore_login/src/hardcoded.js
@@ -22,14 +22,14 @@ const COs = [
 ]
 
 export default [
-  {name: 'Cole', role: 'student', CO: COs[0]},
-  {name: 'Peter', role: 'student', CO: COs[0]},
-  {name: 'Paul', role: 'student', CO: COs[0]},
-  {name: 'Marianne', role: 'student', CO: COs[0]},
-  {name: 'Board', role: 'board', CO: COs[0]},
-  {name: 'Stian', role: 'student', CO: COs[1]},
-  {name: 'Andreas', role: 'student', CO: COs[1]},
-  {name: 'Janne', role: 'student', CO: COs[1]},
-  {name: 'Andrea', role: 'student', CO: COs[2]},
-  {name: 'Agnete', role: 'student', CO: COs[2]}
+  {student: {name: 'Cole', role: 'student', class: 1}, CO: COs[0]},
+  {student: {name: 'Peter', role: 'student', class: 1}, CO: COs[0]},
+  {student: {name: 'Paul', role: 'student', class: 1}, CO: COs[0]},
+  {student: {name: 'Marianne', role: 'student', class: 1}, CO: COs[0]},
+  {student: {name: 'Board', role: 'board', class: 1}, CO: COs[0]},
+  {student: {name: 'Stian', role: 'student', class: 2}, CO: COs[1]},
+  {student: {name: 'Andreas', role: 'student', class: 2}, CO: COs[1]},
+  {student: {name: 'Janne', role: 'student', class: 2}, CO: COs[1]},
+  {student: {name: 'Andrea', role: 'student', class: 2}, CO: COs[2]},
+  {student: {name: 'Agnete', role: 'student', class: 2}, CO: COs[2]}
 ]

--- a/encore_login/src/index.js
+++ b/encore_login/src/index.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import Hardcoded from './hardcoded'
 
-const Student = ( {student, onClick} ) => <li><a href="#" onClick={onClick}>{student.name}</a> <i>{student.CO.name}</i></li>
+const Student = ( {selection, onClick} ) => <li><a href="#" onClick={onClick}>{selection.student.name}</a> <i>{selection.CO.name}</i> Class: {selection.student.class} <b>{selection.student.role}</b></li>
 
 const StudentList = ( {list, selectFn} ) => { return(
-  <div>{list.map(e => {
+  <div>
+  {list.map(e => {
     const clickFn = () => selectFn(e) 
-    return(<Student student={e} onClick={ clickFn }/>)
+    return(<Student selection={e} onClick={ clickFn }/>)
   })}
   </div>
 )}

--- a/horizon-redux-sync/src/index.es6
+++ b/horizon-redux-sync/src/index.es6
@@ -9,7 +9,8 @@ import { omit, sortBy, difference, intersection } from 'lodash'
 // dbname: pouchDb name to sync with (local and external)
 // actionPrefix: will emit redux actions INSERT_ENTRY, UPDATE_ENTRY, DELETE_ENTRY and INITIALIZE_ENTRY
 // filter: object to use when filtering subscriptions, for example {studentid: 1}
-export default (horizon, store, pathStr, dbname, actionPrefix = 'ENTRY', filter) => {
+// options: object, {readOnly: true} means that it only subscribes to Horizon, and not to Redux
+export default (horizon, store, pathStr, dbname, actionPrefix = 'ENTRY', filter, options) => {
   const pathObj = {
     path: pathStr,
     dbname: dbname,
@@ -21,7 +22,9 @@ export default (horizon, store, pathStr, dbname, actionPrefix = 'ENTRY', filter)
   }
 
   listenHorizon(pathObj)
-  store.subscribe(e => reduxChange(pathObj, store.getState()))
+  if (!options || !options.readOnly) { 
+    store.subscribe(e => reduxChange(pathObj, store.getState())) 
+  }
   return pathObj
 }
 


### PR DESCRIPTION
# Changes
- callback object from encore_login now has two objects, student and CO, which is a cleaner approach. 
- the encore_login login list shows all attributes, making it easier to choose the correct one
- horizon redux takes an optional options object, with one current option, {readOnly: true}, which only subscribes to Horizon changes, and does not subscribe to the Redux store - readOnly collections should not have a reducer, since that would bring the Redux collection out of sync with Horizon
- ckx connects to the class_state collection with the appropriate filter upon login
- tablet locking has been successfully implemented
# Structure of class_state (and student_state)

This should really be an object, but because of the way Horizon works, I think it's better if it's an array of objects. Each object has three obligatory keys: 
- class/student (or whatever we need to filter on)
- type (there should only be a single object for a given type and a given class/student/identifier), this is like the key in an object
- value

To get the value out easily for switching, we use getKey from utils (see in StudentView.jsx). 
# Testing

Right now there isn't a way of setting the tablets_locked from CKX, but we can do it directly from the RethinkDB admin panel to test. Run this, replacing the table name for your local table name:

`r.db('ckx').table('class_state_b9c5ebfa3970').insert({type: 'tablets_locked', class: 1, value: true, '$hz_v$': 1})`

Horizon needs $hz_v$ to be set. If you want to change the value (set it back to false again), you can either delete the entry, or you can use update, specifying the ID, and incrementing $hz_v$. (Do not add a second entry with the same class and type).
# Success

I opened two CKX windows, logging into a user in class 1, and one in class 2, and manually set the locking for class 1, that screen was then automatically locked, but the other screen was not. When I updated the entry in RethinkDB to false, the screen unlocked.
# Caution

Before I implemented the readOnly option, the entry in Horizon would be immediately deleted by CKX after inserting it through RethinkDB. I think this is related to the fact that I'm creating it in RethinkDB directly, instead of through Horizon. I'll keep it like this for now, and revisit if it becomes a problem when I'm using Horizon to update this from the admin control panel.
